### PR TITLE
Wip header molly

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^2.8.2",
         "next": "15.3.2",
+        "pretendard": "^1.3.9",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
@@ -23,9 +24,9 @@
         "autoprefixer": "^10.4.21",
         "eslint": "^9",
         "eslint-config-next": "15.3.2",
-        "postcss": "^8.5.3",
+        "postcss": "^8.5.4",
         "prettier": "^3.5.3",
-        "tailwindcss": "^4.1.7"
+        "tailwindcss": "^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1054,6 +1055,12 @@
         "tailwindcss": "4.1.7"
       }
     },
+    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.7.tgz",
+      "integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==",
+      "dev": true
+    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.7.tgz",
@@ -1313,6 +1320,12 @@
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.7"
       }
+    },
+    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.7.tgz",
+      "integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==",
+      "dev": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -5053,9 +5066,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
+      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
       "dev": true,
       "funding": [
         {
@@ -5072,7 +5085,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5095,6 +5108,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
+      "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw=="
     },
     "node_modules/prettier": {
       "version": "3.5.3",
@@ -5857,11 +5875,10 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.7.tgz",
-      "integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
+      "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
+      "dev": true
     },
     "node_modules/tapable": {
       "version": "2.2.2",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.8.2",
     "next": "15.3.2",
+    "pretendard": "^1.3.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
@@ -24,8 +25,8 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
-    "postcss": "^8.5.3",
+    "postcss": "^8.5.4",
     "prettier": "^3.5.3",
-    "tailwindcss": "^4.1.7"
+    "tailwindcss": "^4.1.8"
   }
 }

--- a/react-app/src/app/globals.css
+++ b/react-app/src/app/globals.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
-/*@import 'pretendard/dist/web/static/pretendard.css';*/
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  /*font-family: Arial, Helvetica, sans-serif;*/
+  font-family: 'Pretendard', sans-serif;
 }

--- a/react-app/src/app/globals.css
+++ b/react-app/src/app/globals.css
@@ -1,13 +1,15 @@
-@import "tailwindcss";
+@import 'tailwindcss';
+/*@import 'pretendard/dist/web/static/pretendard.css';*/
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 :root {
-  --background: #F6F5FA;
+  --background: #f6f5fa;
   --foreground: #171717;
-  --gradient-1: #473CE0;
-  --gradient-2: #682FD8; 
+  --gradient-1: #473ce0;
+  --gradient-2: #682fd8;
 }
 
 /* @media (prefers-color-scheme: dark) {
@@ -20,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  /*font-family: Arial, Helvetica, sans-serif;*/
 }

--- a/react-app/src/app/layout.js
+++ b/react-app/src/app/layout.js
@@ -1,5 +1,7 @@
 import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+/*import "./globals.css";*/
+import './globals.css'
+
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/react-app/src/components/Header.jsx
+++ b/react-app/src/components/Header.jsx
@@ -24,7 +24,7 @@ export default function Header() {
             {getCurrentDate()}
           </h2>
         </div>
-        <div className="flex flex-col self-start headerText text-red-500 font-bold text-xl pt-[1.5em] text-left font-pretendard">
+        <div className="flex flex-col self-start headerText text-white font-bold text-xl pt-[1.5em] text-left font-pretendard">
           <h3>
             Find your next <br />
             PeerPick <br />

--- a/react-app/src/components/Header.jsx
+++ b/react-app/src/components/Header.jsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React from 'react'
 
 export default function Header() {
   function getCurrentDate() {
-    const date = new Date();
-    return `${date.getFullYear()}. ${date.getMonth() + 1}. ${date.getDate()}`;
+    const date = new Date()
+    return `${date.getFullYear()}. ${date.getMonth() + 1}. ${date.getDate()}`
   }
 
   return (
@@ -24,14 +24,14 @@ export default function Header() {
             {getCurrentDate()}
           </h2>
         </div>
-        <div className="flex flex-col self-start headerText text-white font-bold text-xl pt-[1.5em] text-left">
+        <div className="flex flex-col self-start headerText text-red-500 font-bold text-xl pt-[1.5em] text-left font-pretendard">
           <h3>
             Find your next <br />
-            PeerPick <br/>
+            PeerPick <br />
             try tags + Keywords
           </h3>
         </div>
       </header>
     </div>
-  );
+  )
 }

--- a/react-app/tailwind.config.js
+++ b/react-app/tailwind.config.js
@@ -1,4 +1,4 @@
-/**manually added this file */
+/**manually added this file- doesn't appear to be working*/
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {

--- a/react-app/tailwind.config.js
+++ b/react-app/tailwind.config.js
@@ -1,0 +1,17 @@
+/**manually added this file */
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+    content: [
+      "./src/**/*.{js,jsx,ts,tsx}",
+    ],
+    theme: {
+      extend: {
+        fontFamily: {
+          pretendard: ['Pretendard', 'sans-serif'],
+        }
+      },
+    },
+    plugins: [],
+  }
+  


### PR DESCRIPTION
I manually added a tailwind.config.js in an attempt to import the pretendard font. It was recommended to take this approach in a build project. For some reason the pretendard text would not apply through the tailwind.confugure.js. So instead I added the font in through the global css page. I was afraid to remove the tailwind.config.js file in case this caused any issues, but I don't think it is actually applying to our files for some reason. 